### PR TITLE
Fixed a bug where the IV parameter conflicts with InformationVariable

### DIFF
--- a/RemoteHashRetrieval.ps1
+++ b/RemoteHashRetrieval.ps1
@@ -928,13 +928,13 @@ Used to decrypt LSA secret with temp key.
 
         [Parameter()]
         [Byte[]]
-        $IV = @(0) * 16
+        $InitializationVector = @(0) * 16
     )
 
     $AES = New-Object System.Security.Cryptography.AesCryptoServiceProvider
     $AES.Mode = "CBC"
     $AES.Key = $Key
-    $AES.IV = $IV
+    $AES.IV = $InitializationVector
     $AES.Padding = [System.Security.Cryptography.PaddingMode]::Zeros
     ($AES.CreateDecryptor()).TransformFinalBlock($CipherText, 0, $CipherText.Length)
 }
@@ -960,7 +960,7 @@ Used to decrypt LSA secret with temp key.
 
         [Parameter()]
         [Byte[]]
-        $IV = @(0) * 16,
+        $InitializationVector = @(0) * 16,
 
         [Parameter()]
         [String]
@@ -969,7 +969,7 @@ Used to decrypt LSA secret with temp key.
 
     $AES = New-Object System.Security.Cryptography.RijndaelManaged
     $AES.Key = $Key 
-    $AES.IV = $IV
+    $AES.IV = $InitializationVector
     $AES.Mode = [System.Security.Cryptography.CipherMode]::CBC
     $AES.Padding = [System.Security.Cryptography.PaddingMode]::$PaddingMode
     $AES.BlockSize = 128
@@ -1720,7 +1720,7 @@ http://moyix.blogspot.com/2008/02/decrypting-lsa-secrets.html
                 }
                 [Array]::Copy($Temp, $CipherText, $Temp.Length)
 
-                $CachePlaintext = Decrypt-Bytes -Key $NLKMKey[0..15] -CipherText $CipherText -IV $CH
+                $CachePlaintext = Decrypt-Bytes -Key $NLKMKey[0..15] -CipherText $CipherText -InitializationVector $CH
 
                 # first 16 bytes of the decrypted result are the username
                 $MsCacheV2 = ([System.BitConverter]::ToString($CachePlaintext[0..15]) -replace '-','').ToLower()


### PR DESCRIPTION
On Windows 10, the `Decrypt-AES` and `Decrypt-Byte` functions have an `IV` parameter that conflict with an alias name of the parameter `InformationVariable`:

```
Decrypt-AES : The parameter 'IV' cannot be specified because it conflicts with the parameter alias of the same 
name for parameter 'InformationVariable'.
At C:\Users\user\Documents\RemoteHashRetrieval.ps1:1282 char:30
+     $LSAKeyStructPlaintext = Decrypt-AES -Key $TmpKey -CipherText $LS ...
+                              ~~~~~~~~~~~
    + CategoryInfo          : MetadataError: (:) [], MetadataException
    + FullyQualifiedErrorId : ParameterNameConflictsWithAlias
```
Changing the `IV` parameter to `InitializationVector` fixes the bug.